### PR TITLE
[PDMVDEV-32] Change SMTP server

### DIFF
--- a/local/email_sender.py
+++ b/local/email_sender.py
@@ -33,12 +33,12 @@ class EmailSender():
             credentials['password'] = self.credentials.split(':')[1]
 
         self.logger.info('Credentials loaded successfully: %s', credentials['username'])
-        self.smtp = smtplib.SMTP(host='smtp.cern.ch', port=587)
+        self.smtp = smtplib.SMTP(host='cernmx.cern.ch', port=25)
         # self.smtp.connect()
         self.smtp.ehlo()
         self.smtp.starttls()
         self.smtp.ehlo()
-        self.smtp.login(credentials['username'], credentials['password'])
+        # self.smtp.login(credentials['username'], credentials['password'])
 
     def __close_smtp(self):
         """


### PR DESCRIPTION
Current SMTP server, smtp.cern.ch, is going to be decomissioned on June 30, 2023 Use the new server for sending emails from applications