### PR TITLE
Update static links

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -6,14 +6,14 @@ from this application
 Attributes:
     CALLBACK_URL (str): This is the url for the endpoint that HTCondor
         jobs use to update the status for the running RelMon job.
-        For example: "https://cms-pdmv.cern.ch/relmonservice/api/update"
+        For example: "https://cms-pdmv-prod.web.cern.ch/relmonservice/api/update"
         For more details, please see the endpoint definition: /api/update.
     SERVICE_URL (str): This is the url for RelMonService2 application.
-        For example: "https://cms-pdmv.cern.ch/relmonservice"
+        For example: "https://cms-pdmv-prod.web.cern.ch/relmonservice"
         It is used to include the application's url into email notifications
         and for request cookies/tokens for authenticating callback request.
     REPORTS_URL (str): This is the url for RelMon report page. 
-        For example: "https://cms-pdmv.cern.ch/relmon"
+        For example: "https://cms-pdmv-prod.web.cern.ch/relmon"
         This is a static web page that renders all outputs for the reports.
     SUBMISSION_HOST (str): This is the server where this application will open an SSH session
         to submit jobs through HTCondor. For example: "lxplus.cern.ch"

--- a/frontend/src/components/RelMonComponent.vue
+++ b/frontend/src/components/RelMonComponent.vue
@@ -12,7 +12,7 @@
           <ul>
             <li><span class="font-weight-light">ID:</span> {{relmonData.id}}</li>
             <li><span class="font-weight-light">Status:</span> <span :title="'HTCondor Status: ' + relmonData.condor_status + '\nHTCondor ID: ' + relmonData.condor_id">{{relmonData.status}}</span> <span v-if="relmonData.status == 'done'">
-              | <a target="_blank" :href="'https://cms-pdmv.cern.ch/relmon?q=' + relmonData.name">go to reports</a>
+              | <a target="_blank" :href="'https://cms-pdmv-prod.web.cern.ch/relmon?q=' + relmonData.name">go to reports</a>
             </span></li>
             <li><span class="font-weight-light">Last update:</span> {{niceDate(relmonData.last_update)}}</li>
           </ul>


### PR DESCRIPTION
1. Replace the old domain for PdmV production

Related to: [PDMVDEV-82](https://its.cern.ch/jira/browse/PDMVDEV-82)